### PR TITLE
Replacing file_line by concat to enable purging of non-managed lines

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -397,12 +397,12 @@ class backuppc::client (
     }
   }
 
-  @@file_line { "backuppc_host_${::fqdn}":
-    ensure  => $ensure,
-    path    => $backuppc::params::hosts,
-    match   => "^${::fqdn}.*$",
-    line    => "${::fqdn} ${hosts_file_dhcp} backuppc ${hosts_file_more_users}\n",
+  @@concat::fragment { "backuppc_host_${::fqdn}":
+    ensure  => present,
+    target  => $backuppc::params::hosts,
+    content => "${::fqdn} ${hosts_file_dhcp} backuppc ${hosts_file_more_users}",
     tag     => "backuppc_hosts_${backuppc_hostname}",
+    order   => '10',
   }
 
   @@file { "${backuppc::params::config_directory}/pc/${::fqdn}.pl":

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -406,7 +406,20 @@ class backuppc::server (
     notify  => Service[$backuppc::params::service],
     require => File["${backuppc::params::config_directory}/pc"],
   }
-  File_line <<| tag == "backuppc_hosts_${::fqdn}" |>> {
+  concat { $backuppc::params::hosts:
+    owner          => 'root',
+    group          => 'root',
+    mode           => '0644',
+    warn           => true,
+    ensure_newline => true,
+    notify         => Service[$backuppc::params::service],
+  }
+  concat::fragment { 'backuppc_hosts_header':
+    target  => $backuppc::params::hosts,
+    content => 'host dhcp user moreUsers',
+    order   => '00',
+  }
+  Concat::Fragment <<| tag == "backuppc_hosts_${::fqdn}" |>> {
     require => Package[$backuppc::params::package],
   }
 


### PR DESCRIPTION
This allow puppet to remove hosts when they are deleted from puppet. 

As a side-effect it will *delete* hosts that are not added by the puppetmodule in that file. 