### PR TITLE
make topdir manageable. Default is package-default setting

### DIFF
--- a/templates/config.pl.erb
+++ b/templates/config.pl.erb
@@ -37,7 +37,7 @@ $Conf{DHCPAddressRanges} = [
 <% end -%>
 <% end -%>];
 $Conf{BackupPCUser} = 'backuppc';
-$Conf{TopDir}      = '<%= scope.lookupvar('backuppc::params::topdir') %>';
+$Conf{TopDir}      = '<%= scope.lookupvar('backuppc::server::topdir') %>';
 $Conf{ConfDir}     = '<%= scope.lookupvar('backuppc::params::config_directory') %>';
 $Conf{LogDir}      = '<%= scope.lookupvar('backuppc::params::log_directory') %>';
 $Conf{InstallDir}  = '<%= scope.lookupvar('backuppc::params::install_directory') %>';


### PR DESCRIPTION
A common setup is to have backuppc use a big partition for the backups. The location of the mount point should not be burried away under /var.
This change makes topdir an optional parameter for the server class, by default filling it with the package-default from params-class.