### PR TITLE
Unit test updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /metadata.json
+Gemfile.lock
+.bundle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+bundler_args: --without system_tests
 rvm:
   - 1.8.7
   - 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,16 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'rake',                    :require => false
-  gem 'rspec-puppet',            :require => false
+  gem 'rspec-puppet', '~> 2.x',  :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'serverspec',              :require => false
-  gem 'rspec-system',            :require => false
-  gem 'rspec-system-puppet',     :require => false
-  gem 'rspec-system-serverspec', :require => false
   gem 'puppet-lint',             :require => false
+end
+
+group :system_tests do
+  gem 'beaker', '~>2.2.0',        :require => false
+  gem 'beaker-rspec',             :require => false
+  gem 'serverspec',               :require => false
+  gem 'pry',                      :require => false unless RUBY_VERSION =~ /^1.8/
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']

--- a/spec/classes/backuppc_client_spec.rb
+++ b/spec/classes/backuppc_client_spec.rb
@@ -4,18 +4,20 @@ describe 'backuppc::client', :type => :class do
 
   describe 'On an unknown operating system' do
     let(:facts) {{ :osfamily => 'Unknown' }}
-    it { should raise_error(Puppet::Error, /is not supported by this module/) }
+    it 'should raise an error' do
+      expect { should compile }.to raise_error(/is not supported by this module/)
+    end
   end
 
   context "On Ubuntu" do
     let(:facts) {{ :osfamily => 'Debian' }}
     let(:params) {{ :backuppc_hostname => 'backuppc.test.com' }}
-    it { should include_class("backuppc::params") }
+    it { should contain_class("backuppc::params") }
   end
 
   context "On RedHat" do
     let(:facts) {{ :osfamily => 'RedHat' }}
     let(:params) {{ :backuppc_hostname => 'backuppc.test.com' }}
-    it { should include_class("backuppc::params") }
+    it { should contain_class("backuppc::params") }
   end
 end

--- a/spec/classes/backuppc_server_spec.rb
+++ b/spec/classes/backuppc_server_spec.rb
@@ -4,20 +4,22 @@ describe 'backuppc::server', :type => :class do
 
   describe 'On an unknown operating system' do
     let(:facts) {{ :osfamily => 'Unknown' }}
-    it { should raise_error(Puppet::Error, /is not supported by this module/) }
+    it 'should raise an error' do
+      expect { should compile }.to raise_error(/is not supported by this module/)
+    end
   end
 
   context "On Ubuntu" do
     let(:facts) {{ :osfamily => 'Debian' }}
     let(:params) {{ :backuppc_password => 'test_password' }}
-    it { should include_class("backuppc::params") }
+    it { should contain_class("backuppc::params") }
     it { should contain_package('backuppc') }
   end
 
   context "On RedHat" do
     let(:facts) {{ :osfamily => 'RedHat' }}
     let(:params) {{ :backuppc_password => 'test_password' }}
-    it { should include_class("backuppc::params") }
+    it { should contain_class("backuppc::params") }
     it { should contain_package('BackupPC') }
   end
 end


### PR DESCRIPTION
* Update rspec-puppet dependency to rspec-puppet 2.x
* Replace rspec-system dependencies with beaker
* Update unit tests

rspec-system has been replaced with beaker and since there are no files actually using rspec-system in this repo I replaced the dependencies.  Having the system test gems in their own group is helpful so that this module's unit tests can be run using Ruby 1.8.7.
