### PR TITLE
fir error with future parser :

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -216,7 +216,7 @@ class backuppc::client (
   $blackout_good_cnt     = false,
   $backups_disable       = false,
   $xfer_method           = 'rsync',
-  $xfer_loglevel         = 1,
+  $xfer_loglevel         = '1',
   $smb_share_name        = false,
   $smb_share_username    = false,
   $smb_share_passwd      = false,


### PR DESCRIPTION
Error: Evaluation Error: Error while evaluating a Function Call, Xfer_loglevel parameter must be a 0, 1 or 2 at .../modules/backuppc/manifests/client.pp:269:3 on node backuppc.exemple.com