### PR TITLE
Added ping6 to config.pl

### DIFF
--- a/templates/config.pl.erb
+++ b/templates/config.pl.erb
@@ -183,6 +183,7 @@ $Conf{NmbLookupFindHostCmd} = '$nmbLookupPath $host';
 $Conf{FixedIPNetBiosNameCheck} = 0;
 $Conf{PingPath} = '/bin/ping';
 $Conf{PingCmd} = '$pingPath -c 1 -w 3 $host';
+$Conf{Ping6Path} = '/bin/ping6';
 $Conf{PingMaxMsec} = 20;
 $Conf{CompressLevel} = 3;
 $Conf{ClientTimeout} = 72000;


### PR DESCRIPTION
As per https://github.com/furhouse/puppet-backuppc/commit/381d1e520801d71eec8ee0bd2f37d75da4b73992#commitcomment-17308362

When the ping6 path is missing, backups fail with backuppc 3.3.0-1ubuntu1.

https://bugs.launchpad.net/ubuntu/+source/backuppc/+bug/782890