### PR TITLE
Add support for exponential backup expiry in full_keep_cnt

### DIFF
--- a/templates/config.pl.erb
+++ b/templates/config.pl.erb
@@ -49,7 +49,7 @@ $Conf{ServerInitdPath} = '';
 $Conf{ServerInitdStartCmd} = '';
 $Conf{FullPeriod} = <%= @full_period %>;
 $Conf{IncrPeriod} = <%= @incr_period %>;
-$Conf{FullKeepCnt} = <%= @full_keep_cnt %>;
+$Conf{FullKeepCnt} = <% if @full_keep_cnt.is_a?(Array) %>[<%= @full_keep_cnt.join(', ') %>]<% else %><%= @full_keep_cnt %><% end %>;
 $Conf{FullKeepCntMin} = 1;
 $Conf{FullAgeMax}     = <%= @full_age_max %>;
 $Conf{IncrKeepCnt} = <%= @incr_keep_cnt %>;

--- a/templates/host.pl.erb
+++ b/templates/host.pl.erb
@@ -13,7 +13,7 @@ $Conf{FullPeriod} = <%= @full_period %>;
 $Conf{IncrPeriod} = <%= @incr_period %>;
 <% end -%>
 <% if @full_keep_cnt -%>
-$Conf{FullKeepCnt} = <%= @full_keep_cnt %>;
+$Conf{FullKeepCnt} = <% if @full_keep_cnt.is_a?(Array) %>[<%= @full_keep_cnt.join(', ') %>]<% else %><%= @full_keep_cnt %><% end %>;
 <% end -%>
 <% if @full_age_max -%>
 $Conf{FullAgeMax}     = <%= @full_age_max %>;


### PR DESCRIPTION
Allow an array to specified for full_keep_cnt/$Conf{FullKeepCnt}, this adds support for exponential backup expiry:

http://backuppc.sourceforge.net/faq/BackupPC.html#What-to-backup-and-when-to-do-it

Then, to set this through hiera, for example, you could do something like this:

`backuppc::server::full_keep_cnt  :
        - '4'
        - '0'
        - '4'
        - '0'
        - '0'
        - '2'
`