### PR TITLE
Changed $log_directory on Debian to use $topdir

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class backuppc::params {
       $cgi_directory      = "${install_directory}/cgi-bin"
       $cgi_image_dir      = "${install_directory}/image"
       $cgi_image_dir_url  = '/backuppc/image'
-      $log_directory      = '/var/lib/backuppc/log'
+      $log_directory      = "${topdir}/log"
       if ($::operatingsystemmajrelease == 6) {
         $config_apache      = '/etc/backuppc/apache.conf'
       } else {


### PR DESCRIPTION
Hi,

I suggest you use $topdir to define $log_directory on Debian. Otherwise, there is no way to move logs elsewhere as there is no variable in server.pp to specify another location for $log_directory.

Regards