### PR TITLE
Fixed bugs when $topdir was changed on Debian

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -353,6 +353,21 @@ class backuppc::server (
     default => $topdir,
   }
 
+  # On Debian, adapt log_directory to $topdir value
+  $real_log_directory = $::osfamily ? {
+    'Debian' => "${topdir}/log",
+    default  => $backuppc::params::log_directory,
+  }
+
+  # If topdir is changed, create a symlink between "default" topdir and the custom
+  # This permit "facter/backuppc_pubkey_rsa" to work properly.
+  if ($real_topdir !~ $backuppc::params::topdir) {
+    file { $backuppc::params::topdir:
+      ensure => link,
+      target => $real_topdir,
+    }
+  }
+
   # Set up dependencies
   Package[$backuppc::params::package] -> File[$backuppc::params::config] -> Service[$backuppc::params::service]
 

--- a/templates/config.pl.erb
+++ b/templates/config.pl.erb
@@ -39,7 +39,7 @@ $Conf{DHCPAddressRanges} = [
 $Conf{BackupPCUser} = 'backuppc';
 $Conf{TopDir}      = '<%= scope.lookupvar('backuppc::server::real_topdir') %>';
 $Conf{ConfDir}     = '<%= scope.lookupvar('backuppc::params::config_directory') %>';
-$Conf{LogDir}      = '<%= scope.lookupvar('backuppc::params::log_directory') %>';
+$Conf{LogDir}      = '<%= scope.lookupvar('backuppc::server::real_log_directory') %>';
 $Conf{InstallDir}  = '<%= scope.lookupvar('backuppc::params::install_directory') %>';
 $Conf{CgiDir}      = '<%= scope.lookupvar('backuppc::params::cgi_directory') %>';
 $Conf{BackupPCUserVerify} = 1;


### PR DESCRIPTION
3rd new PR for the issue when $topdir is changed to a non standard value.
2 bugs where observed:

log_directory was not updated to the appropriate value on Debian. It needs to be "${topdir}/log".
facter to get ssh_key was not working as default $topdir value are hardcoded. The workarround is to create a symlink between standard $topdir and $real_topdir.