### PR TITLE
Add pingmaxmsec param to customize PingMaxMsec config value

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -198,8 +198,12 @@
 #    If set and the Dump/Restore/Archive Pre/Post UserCmd returns a non-zero exit status then the dump/restore/archive is aborted. To maintain backward compatibility (where the exit status in early versions was always ignored), this flag defaults to 0.
 #    If this flag is set and the Dump/Restore/Archive PreUserCmd fails then the matching Dump/Restore/Archive PostUserCmd is not executed. If DumpPreShareCmd returns a non-exit status, then DumpPostShareCmd is not executed, but the DumpPostUserCmd is still run (since DumpPreUserCmd must have previously succeeded).
 #    An example of a DumpPreUserCmd that might fail is a script that snapshots or dumps a database which fails because of some database error.
+#
 # [*topdir*]
 # Overwrite package default location for backuppc.
+#
+# [*pingmaxmsec*]
+# Maximum RTT value (in ms) above which backup won't be started. Default to 20ms
 #
 # === Examples
 #
@@ -257,7 +261,8 @@ class backuppc::server (
   $cgi_admin_users            = 'backuppc',
   $cgi_admin_user_group       = 'backuppc',
   $cgi_date_format_mmdd       = 1,
-  $user_cmd_check_status      =  true,
+  $user_cmd_check_status      = true,
+  $pingmaxmsec                = 20
 ) inherits backuppc::params  {
 
   if empty($backuppc_password) {
@@ -328,6 +333,9 @@ class backuppc::server (
 
   validate_re("${cgi_date_format_mmdd}", '^[012]$',
   'Cgi_date_format_mmdd parameter should be 0-2')
+
+  validate_re("${pingmaxmsec}", '^[1-9]([0-9]*)?$',
+  'pingmaxmsec parameter should be a number')
 
   validate_array($wakeup_schedule)
   validate_array($dhcp_address_ranges)

--- a/templates/config.pl.erb
+++ b/templates/config.pl.erb
@@ -184,7 +184,7 @@ $Conf{FixedIPNetBiosNameCheck} = 0;
 $Conf{PingPath} = '/bin/ping';
 $Conf{PingCmd} = '$pingPath -c 1 -w 3 $host';
 $Conf{Ping6Path} = '/bin/ping6';
-$Conf{PingMaxMsec} = 20;
+$Conf{PingMaxMsec} = <%= @pingmaxmsec %>;
 $Conf{CompressLevel} = 3;
 $Conf{ClientTimeout} = 72000;
 $Conf{MaxOldPerPCLogFiles} = 12;


### PR DESCRIPTION
This PR adds parameter pingmaxmsec to server.pp which is used in config.pl template.

It sets the value of $Conf{PingMaxMsec}, keeping the default value of 20ms.