### PR TITLE
Add sudo_prepend parameter, which prepends a command to the sudo comm…

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -211,6 +211,11 @@
 # to stop/start/browse/restore backups for this host. These users will not be
 # sent email about this host.
 #
+# [*sudo_prepend*]
+# Prepend a command to the sudo command, as run in backuppc.sh. This is mostly
+# useful for running the backup via nice or ionice, in order to reduce the 
+# impact of large backups on the client.
+#
 # === Examples
 #
 #  See tests folder.
@@ -283,6 +288,7 @@ class backuppc::client (
   $email_notify_old_backup_days = false,
   $hosts_file_dhcp       = 0,
   $hosts_file_more_users = '',
+  $sudo_prepend = '',
     ) {
   include backuppc::params
 

--- a/templates/client/backuppc.sh.erb
+++ b/templates/client/backuppc.sh.erb
@@ -6,7 +6,11 @@
 
 case "${SSH_ORIGINAL_COMMAND}" in
   /usr/bin/rsync*|<%= scope.lookupvar('backuppc::params::tar_path') %>*<% if @system_additional_commands.count > 0 %>|<%= @system_additional_commands.join('*|') %>*<% end %> )
+  <%- if @sudo_prepend != '' -%>
+  <%= @sudo_prepend -%> sudo ${SSH_ORIGINAL_COMMAND}
+  <%- else -%>
   sudo ${SSH_ORIGINAL_COMMAND}
+  <%- end - %>
   ;;
 *)
   echo "REJECTED: ${SSH_ORIGINAL_COMMAND}"


### PR DESCRIPTION
…and as run in backuppc.sh. This is mostly useful for running the backup via nice or ionice, in order to reduce the impact of large backups on the client.