### PR TITLE
Allow server class to run when the SSH key fact isn't yet defined

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -361,7 +361,7 @@ class backuppc::client (
       $sudo_commands_noexec = $sudo_command_noexec
     }
 
-    if ! empty($sudo_commands) {
+    if $facts['sudo_commands'] != undef {
       file { '/etc/sudoers.d/backuppc':
         ensure  => $ensure,
         owner   => 'root',

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -390,7 +390,7 @@ class backuppc::client (
       shell      => '/bin/bash',
       comment    => 'BackupPC',
       system     => true,
-      password   => sha1("tyF761_${::fqdn}${::uniqueid}"),
+      password   => '*',
     }
 
     file { "${system_home_directory}/.ssh":

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -479,7 +479,7 @@ class backuppc::server (
 
   # Export backuppc's authorized key to all clients
   # TODO don't rely on facter to obtain the ssh key.
-  if $facts['backupps_pubkey_rsa'] != undef {
+  if $facts['backuppc_pubkey_rsa'] != undef {
     @@ssh_authorized_key { "backuppc_${::fqdn}":
       ensure  => present,
       key     => $::backuppc_pubkey_rsa,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -479,7 +479,7 @@ class backuppc::server (
 
   # Export backuppc's authorized key to all clients
   # TODO don't rely on facter to obtain the ssh key.
-  if ! empty($::backuppc_pubkey_rsa) {
+  if $facts['backupps_pubkey_rsa'] != undef {
     @@ssh_authorized_key { "backuppc_${::fqdn}":
       ensure  => present,
       key     => $::backuppc_pubkey_rsa,


### PR DESCRIPTION
In puppet 4, when you reference a fact using $ notation, this tries to resolve the fact immediately. If it isn't defined because it hasn't been loaded into the external fact directory yet, then the whole manifest refuses to run for that node.  I've changed the evaluation to use the $facts lookup instead. This allows the code to run even when the fact is not yet available so that the node's manifest can load up the RSA key during the first run, and then install the rest of the server keys once the data is available. 