### PR TITLE
Use augeas to set BackupPC host entries

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -497,28 +497,16 @@ class backuppc::server (
     }
   }
 
-  # Since we now tag the hosts that are managed by
-  # puppet, check the current hosts file and compare
-  # it with what is in puppetdb.
-  $dbhosts = query_nodes("Class[backuppc::client]{backuppc_hostname=\"${::fqdn}\"}")
-  $hostsstr = join(sort($dbhosts), '')
-
-  exec { 'tidy_hosts_file':
-    command     => "sed -i '/#puppetmanaged$/d' ${backuppc::params::hosts}",
-    environment => ['LC_ALL=C'],
-    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-    unless      => "test \"$(sed -rn '/#puppetmanaged/ s/^([^ ]+).*/\\1/p' ${backuppc::params::hosts} | sort | tr -d '\\n')\" = \"${hostsstr}\"",
-  }
-
   # Hosts
   File <<| tag == "backuppc_config_${::fqdn}" |>> {
     group   => $backuppc::params::group_apache,
     notify  => Service[$backuppc::params::service],
     require => File["${backuppc::params::config_directory}/pc"],
   }
-  File_line <<| tag == "backuppc_hosts_${::fqdn}" |>> {
-    require => [Package[$backuppc::params::package],Exec['tidy_hosts_file']],
+
+  Augeas <<| tag == "backuppc_hosts_${::fqdn}" |>> {
     notify  => Service[$backuppc::params::service],
+    require => Package[$backuppc::params::package],
   }
 
   Sshkey <<| tag == "backuppc_sshkeys_${::fqdn}" |>>

--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,7 @@
   "project_page": "https://github.com/wyrie/puppet-backuppc",
   "issues_url": "https://github.com/wyrie/puppet-backuppc/issues",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.2"},
-    {"name":"dalen/puppetdbquery","version_requirement":"1.6.1"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.2"}
   ],
   "operatingsystem_support": [
       {

--- a/templates/host-augeas-create.erb
+++ b/templates/host-augeas-create.erb
@@ -1,0 +1,9 @@
+set 01/host <%= @config_name %>
+set 01/dhcp <%= @hosts_file_dhcp %>
+set 01/user <%= @hosts_file_user %>
+<% hosts_file_more_users = @hosts_file_more_users.split(',') -%>
+<% if ! hosts_file_more_users.empty? -%>
+<% hosts_file_more_users.each_with_index do |user, i| -%>
+set 01/moreusers[<%= i + 1 %>] <%= user %>
+<% end -%>
+<% end -%>

--- a/templates/host-augeas-update.erb
+++ b/templates/host-augeas-update.erb
@@ -1,0 +1,10 @@
+set *[host = '<%= @config_name %>']/dhcp <%= @hosts_file_dhcp %>
+set *[host = '<%= @config_name %>']/user <%= @hosts_file_user %>
+<% hosts_file_more_users = @hosts_file_more_users.split(',') -%>
+<% if ! hosts_file_more_users.empty? -%>
+<% hosts_file_more_users.each_with_index do |user, i| -%>
+set *[host = '<%= @config_name %>']/moreusers[<%= i + 1 %>] <%= user %>
+<% end -%>
+<% else -%>
+rm *[host = '<%= @config_name %>']/moreusers
+<% end -%>


### PR DESCRIPTION
I removed the tidy logic, not 100% sure what it did but I've been using the augeas method for a while now and works well.  Allows unmanaged hosts to be added.  If a client goes from managed to unmanaged things are left behind but removing a host in backuppc is a little more involved than what puppet should handle in terms of the items in topdir.